### PR TITLE
Add Order Assembly page and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import ItemsPage from "./pages/Master/Items"
 import axios from "axios"
 import AutoIncreaseQuantity from "./pages/others/AutoIncreaseQuantity"
 import AutoIncreaseItem from "./pages/others/AutoIncreaseItem"
+import OrderAssembly from "./pages/MainAdmin/OrderAssembly"
 import Main from "./users/Main"
 import LoginPage from "./users/LoginPage"
 import Processing from "./users/Processing"
@@ -390,8 +391,9 @@ function App() {
 						<Route path="/admin/editVoucher/:accounting_voucher_uuid" element={<AddVoucher />} />
 
 						<Route path="/admin/AddOutStanding" element={<AddOutStanding />} />
-						<Route path="/admin/addStock" element={<AddStock />} />
-						<Route path="/admin/adjustStock" element={<AdjustStock />} />
+                                                <Route path="/admin/addStock" element={<AddStock />} />
+                                                <Route path="/admin/orderAssembly" element={<OrderAssembly />} />
+                                                <Route path="/admin/adjustStock" element={<AdjustStock />} />
 						<Route path="/admin/userActivity" element={<UserActivity />} />
 						<Route path="/admin/unknownEntry" element={<UknownVouchers />} />
 						<Route path="/admin/SearchTransitionTags" element={<SearchTransitionTags />} />

--- a/src/pages/MainAdmin/MainAdmin.jsx
+++ b/src/pages/MainAdmin/MainAdmin.jsx
@@ -18,7 +18,7 @@ import MessagePopup from "../../components/MessagePopup"
 import TaskPopupMenu from "../../components/TaskPopupMenu"
 import SalesPersoneFilterPopup from "../../components/SalesPersoneFilterPopup"
 import CollectionTag from "../QuikAccess/CollectionTag"
-import { useLocation, useNavigate } from "react-router-dom"
+import { useLocation } from "react-router-dom"
 import context from "../../context/context"
 import { IoCloseCircle } from "react-icons/io5"
 import OrderPrintWrapper from "../../components/OrderPrintWrapper"
@@ -71,7 +71,6 @@ const MainAdmin = () => {
 	const [reminderDate, setReminderDate] = useState()
 	const [selectedtasks, setSelectedTasks] = useState(false)
         const location = useLocation()
-        const navigate = useNavigate()
 	const [notesState, setNotesState] = useState()
 	const [isCooldown, setIsCooldown] = useState(false)
 
@@ -1071,7 +1070,7 @@ TOTAL: ${amounts}
                                                                         : "Show Pending Payments"}
                                                         </button>
                                                         {selectOrder && selectedOrder?.length ? (
-                                                                <button className="simple_Logout_button" onClick={() => navigate("/admin/orderAssembly")}>Order Assembly</button>
+                                                                <button className="simple_Logout_button">Order Assembly</button>
                                                         ) : null}
                                                 </div>
                                         )}

--- a/src/pages/MainAdmin/MainAdmin.jsx
+++ b/src/pages/MainAdmin/MainAdmin.jsx
@@ -18,7 +18,7 @@ import MessagePopup from "../../components/MessagePopup"
 import TaskPopupMenu from "../../components/TaskPopupMenu"
 import SalesPersoneFilterPopup from "../../components/SalesPersoneFilterPopup"
 import CollectionTag from "../QuikAccess/CollectionTag"
-import { useLocation } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 import context from "../../context/context"
 import { IoCloseCircle } from "react-icons/io5"
 import OrderPrintWrapper from "../../components/OrderPrintWrapper"
@@ -70,7 +70,8 @@ const MainAdmin = () => {
 	const [tasks, setTasks] = useState([])
 	const [reminderDate, setReminderDate] = useState()
 	const [selectedtasks, setSelectedTasks] = useState(false)
-	const location = useLocation()
+        const location = useLocation()
+        const navigate = useNavigate()
 	const [notesState, setNotesState] = useState()
 	const [isCooldown, setIsCooldown] = useState(false)
 
@@ -1064,13 +1065,16 @@ TOTAL: ${amounts}
 									)}
 								</>
 							)}
-							<button className="simple_Logout_button" onClick={updatePendingPaymentsVisibility}>
-								{!users?.find(_i => _i?.user_uuid === user_uuid)?.hide_pending_payments
-									? "Hide Pending Payments"
-									: "Show Pending Payments"}
-							</button>
-						</div>
-					)}
+                                                        <button className="simple_Logout_button" onClick={updatePendingPaymentsVisibility}>
+                                                                {!users?.find(_i => _i?.user_uuid === user_uuid)?.hide_pending_payments
+                                                                        ? "Hide Pending Payments"
+                                                                        : "Show Pending Payments"}
+                                                        </button>
+                                                        {selectOrder && selectedOrder?.length ? (
+                                                                <button className="simple_Logout_button" onClick={() => navigate("/admin/orderAssembly")}>Order Assembly</button>
+                                                        ) : null}
+                                                </div>
+                                        )}
 					<div className="content-container" id="content-file-container">
 						{noOrder ? (
 							<div className="noOrder">No Order</div>

--- a/src/pages/MainAdmin/OrderAssembly.jsx
+++ b/src/pages/MainAdmin/OrderAssembly.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Header from "../../components/Header";
+import Sidebar from "../../components/Sidebar";
+
+const OrderAssembly = () => (
+  <>
+    <Sidebar />
+    <Header />
+    <div className="item-sales-container orders-report-container">
+      <div id="heading">
+        <h2>Order Assembly</h2>
+      </div>
+      <div style={{ padding: "20px", textAlign: "center" }}>Coming Soon...</div>
+    </div>
+  </>
+);
+
+export default OrderAssembly;


### PR DESCRIPTION
## Summary
- create Order Assembly page showing "Coming Soon..."
- register Order Assembly route
- add an Order Assembly button that navigates to the new page when orders are selected

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6860f35470ac8322aebfa3a935e2e82b