### PR TITLE
Rename Order Assembly button

### DIFF
--- a/src/pages/MainAdmin/MainAdmin.jsx
+++ b/src/pages/MainAdmin/MainAdmin.jsx
@@ -1071,7 +1071,13 @@ TOTAL: ${amounts}
                                                                         : "Show Pending Payments"}
                                                         </button>
                                                         {selectOrder && selectedOrder?.length ? (
-                                                                <button className="simple_Logout_button">Order Assembly 2</button>
+                                                                {/* Navigate to order assembly page */}
+                                                                <button
+                                                                        className="simple_Logout_button"
+                                                                        onClick={() => navigate("/admin/orderAssembly")}
+                                                                >
+                                                                        Order Assembly
+                                                                </button>
                                                         ) : null}
                                                 </div>
                                         )}


### PR DESCRIPTION
## Summary
- update MainAdmin with button linking to `/admin/orderAssembly`
- document navigation for clarity

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614c5a9a008322b7c21dc7a87f80a2