### PR TITLE
Fix Order Assembly button navigation

### DIFF
--- a/src/pages/MainAdmin/MainAdmin.jsx
+++ b/src/pages/MainAdmin/MainAdmin.jsx
@@ -1071,7 +1071,12 @@ TOTAL: ${amounts}
                                                                         : "Show Pending Payments"}
                                                         </button>
                                                         {selectOrder && selectedOrder?.length ? (
-                                                                <button className="simple_Logout_button">Order Assembly</button>
+                                                                <button
+                                                                        className="simple_Logout_button"
+                                                                        onClick={() => navigate("/admin/orderAssembly")}
+                                                                >
+                                                                        Order Assembly
+                                                                </button>
                                                         ) : null}
                                                 </div>
                                         )}


### PR DESCRIPTION
## Summary
- make Order Assembly button navigate to `/admin/orderAssembly`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615257dbd08322be41be775eea709c