### PR TITLE
Fix Order Assembly button navigation

### DIFF
--- a/src/pages/MainAdmin/MainAdmin.jsx
+++ b/src/pages/MainAdmin/MainAdmin.jsx
@@ -1071,7 +1071,16 @@ TOTAL: ${amounts}
                                                                         : "Show Pending Payments"}
                                                         </button>
                                                         {selectOrder && selectedOrder?.length ? (
-                                                                <button className="simple_Logout_button">Order Assembly</button>
+                                                                <button
+                                                                        className="simple_Logout_button"
+                                                                        onClick={() =>
+                                                                                navigate("/admin/orderAssembly", {
+                                                                                        state: { orders: selectedOrder }
+                                                                                })
+                                                                        }
+                                                                >
+                                                                        Order Assembly
+                                                                </button>
                                                         ) : null}
                                                 </div>
                                         )}

--- a/src/pages/MainAdmin/OrderAssembly.jsx
+++ b/src/pages/MainAdmin/OrderAssembly.jsx
@@ -1,18 +1,31 @@
 import React from "react";
 import Header from "../../components/Header";
 import Sidebar from "../../components/Sidebar";
+import { useLocation } from "react-router-dom";
 
-const OrderAssembly = () => (
-  <>
-    <Sidebar />
-    <Header />
-    <div className="item-sales-container orders-report-container">
-      <div id="heading">
-        <h2>Order Assembly</h2>
+const OrderAssembly = () => {
+  const location = useLocation();
+  const orders = location.state?.orders || [];
+
+  return (
+    <>
+      <Sidebar />
+      <Header />
+      <div className="item-sales-container orders-report-container order-assembly-container">
+        <div id="heading">
+          <h2>Order Assembly</h2>
+        </div>
+        <div className="order-assembly-boxes">
+          {orders.map((item, idx) => (
+            <div key={idx} className="order-assembly-box">
+              {item?.counter_title}
+            </div>
+          ))}
+        </div>
+        <div style={{ padding: "20px", textAlign: "center" }}>Coming Soon...</div>
       </div>
-      <div style={{ padding: "20px", textAlign: "center" }}>Coming Soon...</div>
-    </div>
-  </>
-);
+    </>
+  );
+};
 
 export default OrderAssembly;

--- a/src/pages/MainAdmin/style.css
+++ b/src/pages/MainAdmin/style.css
@@ -113,5 +113,24 @@
 }
 
 .whatsapp-notification-vars button {
-	margin: 0 3px;
+        margin: 0 3px;
+}
+
+.order-assembly-container {
+        position: relative;
+}
+
+.order-assembly-boxes {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        display: flex;
+        gap: 10px;
+}
+
+.order-assembly-box {
+        background: #f0f0f0;
+        padding: 5px 10px;
+        border-radius: 4px;
+        font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- show selected orders on Order Assembly page via navigation state
- display selected orders as boxes on top-right

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615257dbd08322be41be775eea709c