### PR TITLE
Implement order counter list on assembly page

### DIFF
--- a/src/pages/MainAdmin/MainAdmin.jsx
+++ b/src/pages/MainAdmin/MainAdmin.jsx
@@ -1073,7 +1073,13 @@ TOTAL: ${amounts}
                                                         {selectOrder && selectedOrder?.length ? (
                                                                 <button
                                                                         className="simple_Logout_button"
-                                                                        onClick={() => navigate("/admin/orderAssembly")}
+                                                                        onClick={() => {
+                                                                                sessionStorage.setItem(
+                                                                                        "orderAssemblySelectedOrders",
+                                                                                        JSON.stringify(selectedOrder)
+                                                                                )
+                                                                                navigate("/admin/orderAssembly", { state: { orders: selectedOrder } })
+                                                                        }}
                                                                 >
                                                                         Order Assembly
                                                                 </button>

--- a/src/pages/MainAdmin/OrderAssembly.jsx
+++ b/src/pages/MainAdmin/OrderAssembly.jsx
@@ -1,22 +1,51 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import Header from "../../components/Header";
 import Sidebar from "../../components/Sidebar";
 
-const OrderAssembly = () => (
-  <>
-    <Sidebar />
-    <Header />
-    <div className="item-sales-container orders-report-container">
-      <div id="heading">
-        <h2>Order Assembly</h2>
+const OrderAssembly = () => {
+  const location = useLocation();
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    if (location.state?.orders) {
+      setOrders(location.state.orders);
+      sessionStorage.setItem(
+        "orderAssemblySelectedOrders",
+        JSON.stringify(location.state.orders)
+      );
+    } else {
+      const stored = sessionStorage.getItem("orderAssemblySelectedOrders");
+      if (stored) setOrders(JSON.parse(stored));
+    }
+  }, [location.state]);
+
+  const counterTitles = [...new Set(orders.map((o) => o.counter_title).filter(Boolean))];
+
+  return (
+    <>
+      <Sidebar />
+      <Header />
+      <div className="item-sales-container orders-report-container">
+        <div
+          id="heading"
+          style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
+        >
+          <h2>Order Assembly</h2>
+          {counterTitles.length ? (
+            <ul style={{ listStyle: "none", margin: 0, paddingRight: "10px" }}>
+              {counterTitles.map((title) => (
+                <li key={title}>{title}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+        <div style={{ padding: "20px", textAlign: "center", fontSize: "4em" }}>
+          Coming Soon...
+        </div>
       </div>
-      <div
-        style={{ padding: "20px", textAlign: "center", fontSize: "4em" }}
-      >
-        Coming Soon...
-      </div>
-    </div>
-  </>
-);
+    </>
+  );
+};
 
 export default OrderAssembly;


### PR DESCRIPTION
## Summary
- show list of selected counters on `/admin/orderAssembly`
- persist selected orders in sessionStorage when navigating

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686189b3d75c8322937b43f4c6205ef8