### PR TITLE
Update Odoo Counter Id field to accept any characters

### DIFF
--- a/src/pages/Master/Counter.jsx
+++ b/src/pages/Master/Counter.jsx
@@ -1347,14 +1347,14 @@ function NewUserForm({
 											</label>
 											<label className="selectLabel">
 												Odoo Counter Id
-												<input
-													type="number"
-													onWheel={e => e?.preventDefault()}
-													name="odoo_counter_id"
-													className="numberInput"
-													value={data?.odoo_counter_id}
-													onChange={e => setdata({ ...data, odoo_counter_id: e.target.value })}
-												/>
+                                                                              <input
+                                                                              type="text"
+                                                                              onWheel={e => e?.preventDefault()}
+                                                                              name="odoo_counter_id"
+                                                                              className="numberInput"
+                                                                              value={data?.odoo_counter_id}
+                                                                              onChange={e => setdata({ ...data, odoo_counter_id: e.target.value })}
+                                                                              />
 											</label>
 											<label className="selectLabel">
 												Route


### PR DESCRIPTION
## Summary
- allow alphanumeric input for Odoo Counter Id by switching to a text field

## Testing
- `npx vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686194d49ef883229613c9ae0eb9183a