### PR TITLE
Guard missing invoice item IDs

### DIFF
--- a/src/components/ImportInvoices.jsx
+++ b/src/components/ImportInvoices.jsx
@@ -49,16 +49,17 @@ const ImportInvoices = ({ file, onClose }) => {
 					id: dmsInvoice.buyer_id,
 				})
 
-			for (const i of dmsInvoice.items_details) {
-				const item = data.items.find((j) => j.dms_erp_ids.includes(i.dms_erp_id))
-				if (!item) {
-					errors.push({
-						errorType: localErrorTypes.item,
-						name: i.dms_item_name,
-						id: i.dms_erp_id,
-					})
-					continue
-				}
+                        for (const i of dmsInvoice.items_details || []) {
+                                if (!i?.dms_erp_id) continue
+                                const item = data.items.find((j) => j.dms_erp_ids?.includes(i.dms_erp_id))
+                                if (!item) {
+                                        errors.push({
+                                                errorType: localErrorTypes.item,
+                                                name: i.dms_item_name,
+                                                id: i.dms_erp_id,
+                                        })
+                                        continue
+                                }
 
 				const b = parseInt(+item?.conversion ? i.p / +item.conversion : 0)
 				const p = parseInt(+item?.conversion ? i.p % +item.conversion : i.p)
@@ -214,8 +215,12 @@ const ImportInvoices = ({ file, onClose }) => {
 		for (const invoice of json) {
 			payload.dms_counters.push(invoice.buyer_id)
 			payload.dms_users.push(invoice.erp_user)
-			payload.dms_invoice_numbers.push(invoice.invoice_number)
-			payload.dms_items = payload.dms_items.concat(invoice.items_details.map((i) => i.dms_erp_id))
+                        payload.dms_invoice_numbers.push(invoice.invoice_number)
+                        payload.dms_items = payload.dms_items.concat(
+                                (invoice.items_details || [])
+                                        .map((i) => i?.dms_erp_id)
+                                        .filter(Boolean)
+                        )
 		}
 
 		const response = await axios.post("/invoice-import-prerequisite", payload)

--- a/src/components/prints/OrderPrint.jsx
+++ b/src/components/prints/OrderPrint.jsx
@@ -144,8 +144,9 @@ const OrderPrint = ({
 				justifyContent: "space-between"
 			}}
 		>
-			<table style={{ width: "100%" }}>
-				<tr>
+                        <table style={{ width: "100%" }}>
+                                <tbody>
+                                <tr>
 					<td
 						colSpan={32}
 						style={{
@@ -245,8 +246,9 @@ const OrderPrint = ({
 										</tr>
 									) : (
 										""
-									)}
-								</table>
+                                )}
+                                </tbody>
+                        </table>
 							</td>
 						</>
 					) : (
@@ -404,7 +406,7 @@ const OrderPrint = ({
 					</th>
 				</tr>
 
-				{itemDetails?.map((item, i) => {
+                                {itemDetails?.map((item, i) => {
 					const itemInfo = itemData.find(a => a.item_uuid === item.item_uuid)
 					let itemQty = (+item.b || 0) * (+itemInfo?.conversion || 1) + (+item.p || 0)
 					let unit_price = (+item.item_total || 0) / (+itemQty || 1)
@@ -417,8 +419,8 @@ const OrderPrint = ({
 						fontSize: "x-small"
 					}
 
-					return (
-						<tr style={{ borderBottom: "1px solid #000" }} className="order_item">
+                                        return (
+                                                <tr key={item.item_uuid || i} style={{ borderBottom: "1px solid #000" }} className="order_item">
 							<td style={{ fontWeight: "600", fontSize: "x-small" }}>{item?.sr || i + 1}.</td>
 							<td style={boldedItem ? boldItemStyle: {
 								fontWeight: "600",

--- a/src/components/prints/OrderPrint2.jsx
+++ b/src/components/prints/OrderPrint2.jsx
@@ -54,8 +54,8 @@ const OrderPrint2 = ({
 	}, [defaultOrder])
 
 	const reCalculatedItems = useMemo(() => {
-		const items = item_details?.map((item, index) => {
-			const itemInfo = itemData.find((a) => a.item_uuid === item.item_uuid)
+                const items = item_details?.map((item, index) => {
+                        const itemInfo = itemData.find((a) => a.item_uuid === item.item_uuid) || {}
 
 			const itemQty = (+item.b || 0) * (+itemInfo?.conversion || 1) + (+item.p || 0)
 			const unit_price = (+item.item_total || 0) / (+itemQty || 1)
@@ -72,8 +72,8 @@ const OrderPrint2 = ({
 			const returnedItem = {
 				...item,
 				...itemInfo,
-				dms_erp_id: item.dms_erp_id || itemInfo.dms_erp_id,
-				dms_item_name: item.dms_item_name || itemInfo.dms_item_name,
+                                dms_erp_id: item.dms_erp_id || itemInfo.dms_erp_id || "-",
+                                dms_item_name: item.dms_item_name || itemInfo.dms_item_name || "-",
 				item_total: item.item_total?.toFixed(2),
 				desc_amt_a: desc_amt_a?.toFixed(2),
 				desc_amt_b: desc_amt_b?.toFixed(2),
@@ -185,8 +185,9 @@ const OrderPrint2 = ({
           }
         `}
 			</style>
-			<table style={{ width: "100%", borderSpacing: "0px", borderCollapse: "collapse" }}>
-				<tr>
+                        <table style={{ width: "100%", borderSpacing: "0px", borderCollapse: "collapse" }}>
+                                <tbody>
+                                <tr>
 					<th style={{ fontSize: "small" }}>
 						<div
 							style={{
@@ -522,9 +523,9 @@ const OrderPrint2 = ({
 								</th>
 							</tr>
 
-							{reCalculatedItems?.map((item, i) => {
-								return (
-									<tr key={item.item_uuid} style={{ borderBlock: "1px solid black" }} className="order_item">
+                                                        {reCalculatedItems?.map((item, i) => {
+                                                                return (
+                                                                        <tr key={item.item_uuid || i} style={{ borderBlock: "1px solid black" }} className="order_item">
 										<td
 											style={{
 												padding: "0 5px",
@@ -550,7 +551,7 @@ const OrderPrint2 = ({
 												borderInline: "1px solid black",
 											}}
 										>
-											{item?.dms_erp_id}
+                                                                               {item?.dms_erp_id || "-"}
 										</td>
 										<td
 											style={{
@@ -787,8 +788,9 @@ const OrderPrint2 = ({
 										{(+totalItemDetailsMemo?.item_total || 0).toFixed(2)}
 									</td>
 								</tr>
-							) : null}
-						</table>
+                                ) : null}
+                                </tbody>
+                        </table>
 					</td>
 				</tr>
 


### PR DESCRIPTION
## Summary
- handle undefined item info in `OrderPrint2`
- print `-` for blank ERP IDs
- add keys to invoice item rows
- wrap invoice tables with `<tbody>`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623f81dafc8322943a175352705024