### PR TITLE
Restrict spaces in Counter Code field

### DIFF
--- a/src/pages/Master/Counter.jsx
+++ b/src/pages/Master/Counter.jsx
@@ -1485,12 +1485,12 @@ function NewUserForm({
 													name="one_pack"
 													className="numberInput"
 													value={data?.counter_code}
-													onChange={e =>
-														setdata({
-															...data,
-															counter_code: e.target.value
-														})
-													}
+                                                                               onChange={e =>
+                                                                               setdata({
+                                                                               ...data,
+                                                                               counter_code: e.target.value.replace(/\s/g, "")
+                                                                               })
+                                                                               }
 												/>
 											</label>
 											<label className="selectLabel">

--- a/src/pages/Master/TestCounter.jsx
+++ b/src/pages/Master/TestCounter.jsx
@@ -828,12 +828,12 @@ function NewUserForm({ onSave, popupInfo, setCounters, routesData, paymentModes,
 											name="one_pack"
 											className="numberInput"
 											value={data?.counter_code}
-											onChange={e =>
-												setdata({
-													...data,
-													counter_code: e.target.value,
-												})
-											}
+                                                                               onChange={e =>
+                                                                               setdata({
+                                                                               ...data,
+                                                                               counter_code: e.target.value.replace(/\s/g, ""),
+                                                                               })
+                                                                               }
 										/>
 									</label>
 									<label className="selectLabel">

--- a/src/users/AdvanceOrdering.jsx
+++ b/src/users/AdvanceOrdering.jsx
@@ -813,7 +813,7 @@ function NewUserForm({ onSave, popupInfo, refreshDbC }) {
                       onChange={(e) =>
                         setdata({
                           ...data,
-                          counter_code: e.target.value,
+                          counter_code: e.target.value.replace(/\s/g, ""),
                         })
                       }
                     />

--- a/src/users/Orders.jsx
+++ b/src/users/Orders.jsx
@@ -740,12 +740,12 @@ function NewUserForm({ onSave, popupInfo, refreshDbC }) {
 											name="one_pack"
 											className="numberInput"
 											value={data?.counter_code}
-											onChange={e =>
-												setdata({
-													...data,
-													counter_code: e.target.value
-												})
-											}
+                                                                               onChange={e =>
+                                                                               setdata({
+                                                                               ...data,
+                                                                               counter_code: e.target.value.replace(/\s/g, "")
+                                                                               })
+                                                                               }
 										/>
 									</label>
 								</div>


### PR DESCRIPTION
## Summary
- sanitize `counter_code` input to remove spaces across forms

## Testing
- `npx vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6871d63fa4a48322a00eb87b8d5e5c02