### PR TITLE
Fix HSN code handling

### DIFF
--- a/src/pages/Master/HsnCode.jsx
+++ b/src/pages/Master/HsnCode.jsx
@@ -13,8 +13,12 @@ const HSNCode = () => {
   const getUsers = async () => {
     const response = await axios.get("/hsn_code/getHSNCode");
     if (response?.data?.result) {
-      localStorage.setItem("hsn_code", JSON.stringify(response.data.result));
-      setCodes(response.data.result);
+      const formatted = response.data.result.map((i) => ({
+        ...i,
+        hsn_code: i.hsn_code ? i.hsn_code.toString().padStart(8, "0") : "",
+      }));
+      localStorage.setItem("hsn_code", JSON.stringify(formatted));
+      setCodes(formatted);
     }
   };
 
@@ -206,7 +210,13 @@ function NewUserForm({ onSave, popupInfo, setUsers }) {
   });
   const [errMassage, setErrorMassage] = useState("");
   useEffect(() => {
-    if (popupInfo?.type === "edit") setdata(popupInfo.data);
+    if (popupInfo?.type === "edit")
+      setdata({
+        ...popupInfo.data,
+        hsn_code: popupInfo.data.hsn_code
+          ? popupInfo.data.hsn_code.toString().padStart(8, "0")
+          : "",
+      });
   }, [popupInfo.data, popupInfo?.type]);
 
   const submitHandler = async (e) => {
@@ -289,7 +299,7 @@ function NewUserForm({ onSave, popupInfo, setUsers }) {
                   <label className="selectLabel">
                     HSN Code
                     <input
-                      type="number"
+                      type="text"
                       name="sort_order"
                       className="numberInput"
                       value={data?.hsn_code}
@@ -299,6 +309,7 @@ function NewUserForm({ onSave, popupInfo, setUsers }) {
                           hsn_code: e.target.value,
                         })
                       }
+                      maxLength={8}
                     />
                   </label>
                 </div>

--- a/src/pages/Master/Items.jsx
+++ b/src/pages/Master/Items.jsx
@@ -56,7 +56,13 @@ const ItemsPage = () => {
         "Content-Type": "application/json",
       },
     });
-    if (response.data.success) setItemsData(response.data.result);
+    if (response.data.success)
+      setItemsData(
+        response.data.result.map((item) => ({
+          ...item,
+          hsn: item.hsn ? item.hsn.toString().padStart(8, "0") : "",
+        }))
+      );
   };
   useEffect(() => {
     const controller = new AbortController();
@@ -769,6 +775,9 @@ function NewUserForm({
         conversion: "1",
         status: 1,
         ...popupInfo.data,
+        hsn: popupInfo.data.hsn
+          ? popupInfo.data.hsn.toString().padStart(8, "0")
+          : "",
       });
     else if (popupInfo?.type === "price")
       setdata({
@@ -834,6 +843,13 @@ function NewUserForm({
       setErrorMassage("Please insert Unique Barcode");
       return;
     }
+
+    if (!/^[0-9]{8}$/.test(obj.hsn)) {
+      setNotification({ success: false, message: "HSN Code should be of 8 digit" });
+      return;
+    }
+
+    obj.hsn = obj.hsn.toString().padStart(8, "0");
 
     if (obj.img) {
       const previousFile = obj.img;
@@ -1436,7 +1452,7 @@ function NewUserForm({
                       <label className="selectLabel">
                         Product HSN
                         <input
-                          type="number"
+                          type="text"
                           name="one_pack"
                           className="numberInput"
                           value={data?.hsn}
@@ -1448,7 +1464,6 @@ function NewUserForm({
                               });
                           }}
                           maxLength={8}
-                          // disabled={true}
                         />
                       </label>
                       <label className="selectLabel" style={{ width: "100px" }}>


### PR DESCRIPTION
## Summary
- keep HSN codes padded to eight digits when editing and saving items
- show toast error with proper styling when HSN length is invalid
- allow leading zeros for HSN codes in the HSN master list

## Testing
- `npx vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6871d9854fb48322b9a77834d66f8228